### PR TITLE
Support R# 2020.2

### DIFF
--- a/.teamcity/OpenSourceProjects_ImplicitNullability/buildTypes/OpenSourceProjects_ImplicitNullability_BuildVersion.xml
+++ b/.teamcity/OpenSourceProjects_ImplicitNullability/buildTypes/OpenSourceProjects_ImplicitNullability_BuildVersion.xml
@@ -7,7 +7,7 @@
       <option name="buildNumberPattern" value="%Version%.%build.counter%" />
     </options>
     <parameters>
-      <param name="Version" value="4.10.0" />
+      <param name="Version" value="4.11.0" />
     </parameters>
     <build-runners />
     <vcs-settings />

--- a/Build/Build.ps1
+++ b/Build/Build.ps1
@@ -15,7 +15,7 @@ trap { $error[0] | Format-List -Force; $host.SetShouldExit(1) }
 
 $BuildOutputPath = "Build\Output"
 $SolutionFilePath = "ImplicitNullability.sln"
-$MSBuildPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\*\MSBuild\15.0\Bin\MSBuild.exe").FullName
+$MSBuildPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\*\MSBuild\16.0\Bin\MSBuild.exe").FullName
 $MSBuildAdditionalArgs = "/nowarn:MSB3277"
 $NUnitAdditionalArgs = "--x86 --labels=All --agents=1"
 $NUnitTestAssemblyPaths = @(

--- a/Build/Build.ps1
+++ b/Build/Build.ps1
@@ -19,15 +19,15 @@ $MSBuildPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\
 $MSBuildAdditionalArgs = "/nowarn:MSB3277"
 $NUnitAdditionalArgs = "--x86 --labels=All --agents=1"
 $NUnitTestAssemblyPaths = @(
-    "Src\ImplicitNullability.Plugin.Tests\bin\RD20201\$Configuration\ImplicitNullability.Plugin.Tests.RD20201.dll"
-    "Src\ImplicitNullability.Plugin.Tests\bin\RS20201\$Configuration\ImplicitNullability.Plugin.Tests.RS20201.dll"
+    "Src\ImplicitNullability.Plugin.Tests\bin\RD20202\$Configuration\ImplicitNullability.Plugin.Tests.RD20202.dll"
+    "Src\ImplicitNullability.Plugin.Tests\bin\RS20202\$Configuration\ImplicitNullability.Plugin.Tests.RS20202.dll"
     "Src\ImplicitNullability.Samples.Consumer\bin\OfInternalCodeWithIN\$Configuration\ImplicitNullability.Samples.Consumer.OfInternalCodeWithIN.dll"
 )
 $NUnitFrameworkVersion = "net-4.5"
 $TestCoverageFilter = "+[ImplicitNullability*]* -[ImplicitNullability*]ReSharperExtensionsShared.* -[ImplicitNullability.Samples.CodeWithIN.*]* -[ImplicitNullability.Samples.CodeWithoutIN.External]*"
 $NuspecPath = "Src\ImplicitNullability.Plugin\ImplicitNullability.nuspec"
 $NugetPackProperties = @(
-    "Version=$(CalcNuGetPackageVersion 20201);Configuration=$Configuration;DependencyVer=[201.0];BinDirInclude=bin\RS20201"
+    "Version=$(CalcNuGetPackageVersion 20202);Configuration=$Configuration;DependencyVer=[201.0];BinDirInclude=bin\RS20202"
 )
 $RiderPluginProject = "Src\RiderPlugin"
 $NugetPushServer = "https://www.myget.org/F/ulrichb/api/v2/package"

--- a/Build/Build.ps1
+++ b/Build/Build.ps1
@@ -27,7 +27,7 @@ $NUnitFrameworkVersion = "net-4.5"
 $TestCoverageFilter = "+[ImplicitNullability*]* -[ImplicitNullability*]ReSharperExtensionsShared.* -[ImplicitNullability.Samples.CodeWithIN.*]* -[ImplicitNullability.Samples.CodeWithoutIN.External]*"
 $NuspecPath = "Src\ImplicitNullability.Plugin\ImplicitNullability.nuspec"
 $NugetPackProperties = @(
-    "Version=$(CalcNuGetPackageVersion 20202);Configuration=$Configuration;DependencyVer=[201.0];BinDirInclude=bin\RS20202"
+    "Version=$(CalcNuGetPackageVersion 20202);Configuration=$Configuration;DependencyVer=[202.0];BinDirInclude=bin\RS20202"
 )
 $RiderPluginProject = "Src\RiderPlugin"
 $NugetPushServer = "https://www.myget.org/F/ulrichb/api/v2/package"

--- a/Build/Build.ps1
+++ b/Build/Build.ps1
@@ -15,7 +15,7 @@ trap { $error[0] | Format-List -Force; $host.SetShouldExit(1) }
 
 $BuildOutputPath = "Build\Output"
 $SolutionFilePath = "ImplicitNullability.sln"
-$MSBuildPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\*\MSBuild\16.0\Bin\MSBuild.exe").FullName
+$MSBuildPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\*\MSBuild\Current\Bin\MSBuild.exe").FullName
 $MSBuildAdditionalArgs = "/nowarn:MSB3277"
 $NUnitAdditionalArgs = "--x86 --labels=All --agents=1"
 $NUnitTestAssemblyPaths = @(

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+### 4.11.0 ###
+- (!) End-of-life note: Please switch to C# 8 Nullable Reference Types
+- ReSharper and Rider 2020.2 support
+
 ### 4.10.0 ###
 - (!) End-of-life note: Please switch to C# 8 Nullable Reference Types
 - ReSharper and Rider 2020.1 support

--- a/ImplicitNullability.sln
+++ b/ImplicitNullability.sln
@@ -26,17 +26,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImplicitNullability.Samples
 		{C98DF2CD-3BB5-4213-9D90-08241ED5B74F} = {C98DF2CD-3BB5-4213-9D90-08241ED5B74F}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.VsFormatDefinitions.RS20201", "Src\ImplicitNullability.Plugin.VsFormatDefinitions\ImplicitNullability.Plugin.VsFormatDefinitions.RS20201.csproj", "{69D96DC8-E1A0-4412-AD54-BAEC0B43520E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.VsFormatDefinitions.RS20202", "Src\ImplicitNullability.Plugin.VsFormatDefinitions\ImplicitNullability.Plugin.VsFormatDefinitions.RS20202.csproj", "{69D96DC8-E1A0-4412-AD54-BAEC0B43520E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.RS20201", "Src\ImplicitNullability.Plugin\ImplicitNullability.Plugin.RS20201.csproj", "{2F246B16-414A-4FDF-9DE2-3EC8E51D1B9A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.RS20202", "Src\ImplicitNullability.Plugin\ImplicitNullability.Plugin.RS20202.csproj", "{2F246B16-414A-4FDF-9DE2-3EC8E51D1B9A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.Tests.RS20201", "Src\ImplicitNullability.Plugin.Tests\ImplicitNullability.Plugin.Tests.RS20201.csproj", "{1C93B659-62A2-4539-815D-D20BABB47451}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.Tests.RS20202", "Src\ImplicitNullability.Plugin.Tests\ImplicitNullability.Plugin.Tests.RS20202.csproj", "{1C93B659-62A2-4539-815D-D20BABB47451}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImplicitNullability.Samples.CodeWithIN.Special", "Src\ImplicitNullability.Samples.CodeWithIN.Special\ImplicitNullability.Samples.CodeWithIN.Special.csproj", "{4979B806-EB66-4C3F-8BB0-7AF284AEB0BD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.RD20201", "Src\ImplicitNullability.Plugin\ImplicitNullability.Plugin.RD20201.csproj", "{4ECAB56A-44C9-4A46-B401-FBD782634AA0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.RD20202", "Src\ImplicitNullability.Plugin\ImplicitNullability.Plugin.RD20202.csproj", "{4ECAB56A-44C9-4A46-B401-FBD782634AA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.Tests.RD20201", "Src\ImplicitNullability.Plugin.Tests\ImplicitNullability.Plugin.Tests.RD20201.csproj", "{2E9FE56E-2507-42FC-8146-2F4F9BA4397D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitNullability.Plugin.Tests.RD20202", "Src\ImplicitNullability.Plugin.Tests\ImplicitNullability.Plugin.Tests.RD20202.csproj", "{2E9FE56E-2507-42FC-8146-2F4F9BA4397D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-:warning: **End-of-life note:** C# 8+ (VS 2019+) supports [_nullable reference types_](https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types) which [supersedes](#c-nullable-reference-types) - and perfectly aligns with - _Implicit Nullability_. Therefore ReSharper/Rider 2020.1 is the last version supported by _Implicit Nullability_.
+:warning: **End-of-life note:** C# 8+ (VS 2019+) supports [_nullable reference types_](https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types) which [supersedes](#c-nullable-reference-types) - and perfectly aligns with - _Implicit Nullability_. Therefore ReSharper/Rider 2020.2 is the last version supported by _Implicit Nullability_.
 
 ## Implicit Nullability ReSharper Extension
 

--- a/Src/ImplicitNullability.Plugin.Tests/ImplicitNullability.Plugin.Tests.RD20202.csproj
+++ b/Src/ImplicitNullability.Plugin.Tests/ImplicitNullability.Plugin.Tests.RD20202.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.1.*" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.2.*" />
     <PackageReference Include="FakeItEasy" Version="4.*" />
     <PackageReference Include="ncalc" Version="1.3.*" />
   </ItemGroup>

--- a/Src/ImplicitNullability.Plugin.Tests/ImplicitNullability.Plugin.Tests.RS20202.csproj
+++ b/Src/ImplicitNullability.Plugin.Tests/ImplicitNullability.Plugin.Tests.RS20202.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.1.*" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.2.*" />
     <PackageReference Include="FakeItEasy" Version="4.*" />
     <PackageReference Include="ncalc" Version="1.3.*" />
   </ItemGroup>

--- a/Src/ImplicitNullability.Plugin.Tests/UnitTests/AnnotationRedundancyInHierarchyWarningFilteringDecoratorTest.cs
+++ b/Src/ImplicitNullability.Plugin.Tests/UnitTests/AnnotationRedundancyInHierarchyWarningFilteringDecoratorTest.cs
@@ -28,7 +28,7 @@ namespace ImplicitNullability.Plugin.Tests.UnitTests
 
             _sut.ConsumeHighlighting(highlightingInfo);
 
-            A_.CallTo(() => _decorated.ConsumeHighlighting(highlightingInfo)).MustHaveHappened();
+            A_.CallTo(() => _decorated.ConsumeHighlighting(highlightingInfo, null, null)).MustHaveHappened();
         }
 
         [Test]

--- a/Src/ImplicitNullability.Plugin.VsFormatDefinitions/ImplicitNullability.Plugin.VsFormatDefinitions.RS20202.csproj
+++ b/Src/ImplicitNullability.Plugin.VsFormatDefinitions/ImplicitNullability.Plugin.VsFormatDefinitions.RS20202.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.1.*" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.*" />
     <PackageReference Include="VSSDK.Text.10" Version="10.*" />
   </ItemGroup>
 

--- a/Src/ImplicitNullability.Plugin/AnnotationRedundancyInHierarchyWarningFilteringDecorator.cs
+++ b/Src/ImplicitNullability.Plugin/AnnotationRedundancyInHierarchyWarningFilteringDecorator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Daemon.CSharp.Errors;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
@@ -13,7 +14,7 @@ namespace ImplicitNullability.Plugin
             _decorated = decorated;
         }
 
-        public void ConsumeHighlighting(HighlightingInfo highlightingInfo)
+        public void ConsumeHighlighting(HighlightingInfo highlightingInfo, DocumentRange[] secondaryDocumentRanges = null, string secondaryAttributeId = null)
         {
             if (!(highlightingInfo.Highlighting is AnnotationRedundancyInHierarchyWarning))
             {

--- a/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullConflictInHierarchyHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullConflictInHierarchyHighlighting.cs
@@ -1,18 +1,17 @@
-﻿using ImplicitNullability.Plugin.Highlighting;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
 
-[assembly: RegisterConfigurableSeverity(
-    ImplicitNotNullConflictInHierarchyHighlighting.SeverityId,
-    CompoundItemName: null,
-    Group: HighlightingGroupIds.CodeSmell,
-    Title: ImplicitNotNullConflictInHierarchyHighlighting.Message,
-    Description: ImplicitNotNullConflictInHierarchyHighlighting.Description,
-    DefaultSeverity: Severity.WARNING)]
-
 namespace ImplicitNullability.Plugin.Highlighting
 {
+    [RegisterConfigurableSeverity(
+        SeverityId,
+        CompoundItemName: null,
+        Group: HighlightingGroupIds.CodeSmell,
+        Title: Message,
+        Description: Description,
+        DefaultSeverity: Severity.WARNING)]
+
     [ConfigurableSeverityHighlighting(
         SeverityId,
         CSharpLanguage.Name,

--- a/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullElementCannotOverrideCanBeNullHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullElementCannotOverrideCanBeNullHighlighting.cs
@@ -1,18 +1,17 @@
-﻿using ImplicitNullability.Plugin.Highlighting;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
 
-[assembly: RegisterConfigurableSeverity(
-    ImplicitNotNullElementCannotOverrideCanBeNullHighlighting.SeverityId,
-    CompoundItemName: null,
-    Group: HighlightingGroupIds.CodeSmell,
-    Title: ImplicitNotNullElementCannotOverrideCanBeNullHighlighting.Message,
-    Description: ImplicitNotNullElementCannotOverrideCanBeNullHighlighting.Description,
-    DefaultSeverity: Severity.WARNING)]
-
 namespace ImplicitNullability.Plugin.Highlighting
 {
+    [RegisterConfigurableSeverity(
+        SeverityId,
+        CompoundItemName: null,
+        Group: HighlightingGroupIds.CodeSmell,
+        Title: Message,
+        Description: Description,
+        DefaultSeverity: Severity.WARNING)]
+
     [ConfigurableSeverityHighlighting(
         SeverityId,
         CSharpLanguage.Name,

--- a/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullOverridesUnknownBaseMemberNullabilityHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullOverridesUnknownBaseMemberNullabilityHighlighting.cs
@@ -1,19 +1,17 @@
-﻿using ImplicitNullability.Plugin.Highlighting;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
 
-[assembly: RegisterConfigurableSeverity(
-    ImplicitNotNullOverridesUnknownBaseMemberNullabilityHighlighting.SeverityId,
-    CompoundItemName: null,
-    Group: HighlightingGroupIds.CodeSmell,
-    Title: ImplicitNotNullOverridesUnknownBaseMemberNullabilityHighlighting.Message,
-    Description: ImplicitNotNullOverridesUnknownBaseMemberNullabilityHighlighting.Description,
-    DefaultSeverity: Severity.WARNING,
-    AlternativeIDs = "ImplicitNotNullOverridesUnknownExternalMember")]
-
 namespace ImplicitNullability.Plugin.Highlighting
 {
+    [RegisterConfigurableSeverity(
+        SeverityId,
+        CompoundItemName: null,
+        Group: HighlightingGroupIds.CodeSmell,
+        Title: Message,
+        Description: Description,
+        DefaultSeverity: Severity.WARNING,
+        AlternativeIDs = "ImplicitNotNullOverridesUnknownExternalMember")]
     [ConfigurableSeverityHighlighting(
         SeverityId,
         CSharpLanguage.Name,

--- a/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullResultOverridesUnknownBaseMemberNullabilityHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/Highlighting/ImplicitNotNullResultOverridesUnknownBaseMemberNullabilityHighlighting.cs
@@ -1,19 +1,17 @@
-﻿using ImplicitNullability.Plugin.Highlighting;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
 
-[assembly: RegisterConfigurableSeverity(
-    ImplicitNotNullResultOverridesUnknownBaseMemberNullabilityHighlighting.SeverityId,
-    CompoundItemName: null,
-    Group: HighlightingGroupIds.CodeSmell,
-    Title: ImplicitNotNullResultOverridesUnknownBaseMemberNullabilityHighlighting.Message,
-    Description: ImplicitNotNullResultOverridesUnknownBaseMemberNullabilityHighlighting.Description,
-    DefaultSeverity: Severity.HINT,
-    AlternativeIDs = "ImplicitNotNullResultOverridesUnknownExternalMember")]
-
 namespace ImplicitNullability.Plugin.Highlighting
 {
+    [RegisterConfigurableSeverity(
+        SeverityId,
+        CompoundItemName: null,
+        Group: HighlightingGroupIds.CodeSmell,
+        Title: Message,
+        Description: Description,
+        DefaultSeverity: Severity.HINT,
+        AlternativeIDs = "ImplicitNotNullResultOverridesUnknownExternalMember")]
     [ConfigurableSeverityHighlighting(
         SeverityId,
         CSharpLanguage.Name,

--- a/Src/ImplicitNullability.Plugin/Highlighting/NotNullOnImplicitCanBeNullHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/Highlighting/NotNullOnImplicitCanBeNullHighlighting.cs
@@ -1,18 +1,16 @@
-﻿using ImplicitNullability.Plugin.Highlighting;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
 
-[assembly: RegisterConfigurableSeverity(
-    NotNullOnImplicitCanBeNullHighlighting.SeverityId,
-    CompoundItemName: null,
-    Group: HighlightingGroupIds.CodeSmell,
-    Title: NotNullOnImplicitCanBeNullHighlighting.Message,
-    Description: NotNullOnImplicitCanBeNullHighlighting.Description,
-    DefaultSeverity: Severity.WARNING)]
-
 namespace ImplicitNullability.Plugin.Highlighting
 {
+    [RegisterConfigurableSeverity(
+        SeverityId,
+        CompoundItemName: null,
+        Group: HighlightingGroupIds.CodeSmell,
+        Title: Message,
+        Description: Description,
+        DefaultSeverity: Severity.WARNING)]
     [ConfigurableSeverityHighlighting(
         SeverityId,
         CSharpLanguage.Name,

--- a/Src/ImplicitNullability.Plugin/ImplicitNullability.Plugin.RD20202.csproj
+++ b/Src/ImplicitNullability.Plugin/ImplicitNullability.Plugin.RD20202.csproj
@@ -14,19 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.1.*" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.2.*" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ImplicitNullability.Plugin.VsFormatDefinitions\ImplicitNullability.Plugin.VsFormatDefinitions.$(ReSharperVersionIdentifier).csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFilesForReSharperInstallationsDirectory Include="$(OutDir)ImplicitNullability.Plugin.VsFormatDefinitions.*" />
   </ItemGroup>
 
 </Project>

--- a/Src/ImplicitNullability.Plugin/ImplicitNullability.Plugin.RS20202.csproj
+++ b/Src/ImplicitNullability.Plugin/ImplicitNullability.Plugin.RS20202.csproj
@@ -14,11 +14,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.1.*" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.*" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImplicitNullability.Plugin.VsFormatDefinitions\ImplicitNullability.Plugin.VsFormatDefinitions.$(ReSharperVersionIdentifier).csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFilesForReSharperInstallationsDirectory Include="$(OutDir)ImplicitNullability.Plugin.VsFormatDefinitions.*" />
   </ItemGroup>
 
 </Project>

--- a/Src/ImplicitNullability.Plugin/TypeHighlighting/StaticNullabilityItemTypeHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/TypeHighlighting/StaticNullabilityItemTypeHighlighting.cs
@@ -1,4 +1,3 @@
-using ImplicitNullability.Plugin.TypeHighlighting;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
@@ -6,18 +5,18 @@ using JetBrains.TextControl.DocumentMarkup;
 
 // For ReSharper/VS's format definition, see NullabilityItemTypeHighlightingClassificationFormatDefinition
 
-[assembly: RegisterHighlighter(
-    StaticNullabilityItemTypeHighlighting.HighlightingId,
-    EffectColor = "#FF7CE3",
-    EffectType = EffectType.DOTTED_UNDERLINE,
-    Layer = HighlighterLayer.SYNTAX,
-    VSPriority = VSPriority.IDENTIFIERS)]
-
 namespace ImplicitNullability.Plugin.TypeHighlighting
 {
+    [RegisterHighlighter(
+        HighlightingId,
+        EffectColor = "#FF7CE3",
+        EffectType = EffectType.DOTTED_UNDERLINE,
+        Layer = HighlighterLayer.SYNTAX,
+        VSPriority = VSPriority.IDENTIFIERS)]
     [StaticSeverityHighlighting(
         Severity.INFO,
-        CSharpLanguage.Name,
+        typeof(HighlightingGroupIds.CodeSmellStatic),
+        Languages = CSharpLanguage.Name,
         AttributeId = HighlightingId,
         ShowToolTipInStatusBar = false,
         ToolTipFormatString = Message)]

--- a/Src/ImplicitNullability.Plugin/TypeHighlighting/StaticNullabilityTypeHighlighting.cs
+++ b/Src/ImplicitNullability.Plugin/TypeHighlighting/StaticNullabilityTypeHighlighting.cs
@@ -1,4 +1,3 @@
-using ImplicitNullability.Plugin.TypeHighlighting;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;
@@ -6,18 +5,18 @@ using JetBrains.TextControl.DocumentMarkup;
 
 // For ReSharper/VS's format definition, see NullabilityTypeHighlightingClassificationFormatDefinition
 
-[assembly: RegisterHighlighter(
-    StaticNullabilityTypeHighlighting.HighlightingId,
-    EffectColor = "#E53DFF",
-    EffectType = EffectType.DOTTED_UNDERLINE,
-    Layer = HighlighterLayer.SYNTAX,
-    VSPriority = VSPriority.IDENTIFIERS)]
-
 namespace ImplicitNullability.Plugin.TypeHighlighting
 {
+    [RegisterHighlighter(
+        HighlightingId,
+        EffectColor = "#E53DFF",
+        EffectType = EffectType.DOTTED_UNDERLINE,
+        Layer = HighlighterLayer.SYNTAX,
+        VSPriority = VSPriority.IDENTIFIERS)]
     [StaticSeverityHighlighting(
         Severity.INFO,
-        CSharpLanguage.Name,
+        typeof(HighlightingGroupIds.CodeSmellStatic),
+        Languages = CSharpLanguage.Name,
         AttributeId = HighlightingId,
         ShowToolTipInStatusBar = false,
         ToolTipFormatString = Message)]

--- a/Src/RiderPlugin/build.gradle
+++ b/Src/RiderPlugin/build.gradle
@@ -16,7 +16,7 @@ if (!project.hasProperty('configuration')) ext.configuration = 'Debug'
 intellij {
     type = 'RD'
     // https://www.jetbrains.com/intellij-repository/releases
-    version = '2020.1.0'
+    version = '2020.2.0'
     downloadSources = false
 }
 
@@ -25,7 +25,7 @@ compileKotlin {
 }
 
 prepareSandbox {
-    from("$projectDir/../$gradle.resharperPluginProjectName/bin/RD20201/$configuration", {
+    from("$projectDir/../$gradle.resharperPluginProjectName/bin/RD20202/$configuration", {
         into "$intellij.pluginName/dotnet"
         include "$gradle.resharperPluginProjectName*"
     })


### PR DESCRIPTION
Hi!
Was müsste ich tun damit da nochmal ein Release passiert? :o)

Bei mir laufen die integrativen Tests lokal nicht, muss man da irgendein SDK noch installiert haben? Genau die R# version installiert haben, die man supporten möchte?

Nur falls es einfach geht ... falls nicht, dann können wir halt jetzt mal noch ein Zeiterl keinen R# oder Rider updaten.

LG
